### PR TITLE
fix: Deprecate region argument

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -1,7 +1,10 @@
 /* vim: ts=2:sw=2:sts=0:expandtab */
+data "aws_region" "current" {}
 data "aws_caller_identity" "current" {}
 locals {
   tags = merge(var.tags, { environment = terraform.workspace, env = terraform.workspace, name = var.name })
+
+  region = data.aws_region.current.name
 
   environs = merge(var.environment, { environment = terraform.workspace })
   environ = [
@@ -45,7 +48,7 @@ locals {
       logDriver = "awslogs"
         options = {
           awslogs-create-group = "true"
-          awslogs-region = var.region
+          awslogs-region = local.region
           awslogs-group = var.family
           awslogs-stream-prefix = var.prefix
         }

--- a/variables.tf
+++ b/variables.tf
@@ -39,7 +39,8 @@ variable "exec_role_arn" {
 }
 
 variable "region" {
-  default = ""
+  description = "Deployment region (deprecated)"
+  default = "unused"
 }
 
 variable "public" {
@@ -256,7 +257,6 @@ variable "elkendpoint" {
 
 locals {
   vpc_id = var.vpc_id == "" ? var.cluster["vpc_id"] : var.vpc_id
-  region = var.region == "" ? var.cluster["region"] : var.region
   family = var.family == "" ? var.name : var.family
   prefix = var.prefix == "" ? local.family : var.prefix
 


### PR DESCRIPTION
The use of region parameters is generally deprecated across terraform
and AWS.  We should be leveraging the current region as specified in the
provider session.