### PR TITLE
fix:Update 'alarm_5xx_error_pct' to 30

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -294,7 +294,7 @@ variable "alarm_unhealthy_task_period" {
 
 variable "alarm_5xx_error_percent" {
   description = "5xx error percentile alarm"
-  default     = 20
+  default     = 30
 }
 
 variable "alarm_5xx_error_period" {


### PR DESCRIPTION
Update alarm_5xx_error_percent variable default value to 30 from 20. This was requested to suppress alert noise for community-service.